### PR TITLE
Stac 2747 etc perms

### DIFF
--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -46,6 +46,7 @@ build do
   if linux?
     # Configuration files
     mkdir '/etc/sts-agent'
+    mkdir '/etc/sts-agent/branch_marker'
     command "chmod -R 0640 /etc/sts-agent"
 
     if debian?

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -45,12 +45,9 @@ build do
 
   if linux?
     # Configuration files
-    directory '/etc/sts-agent' do
-      owner 'sts-agent'
-      group 'sts-agent'
-      mode '0640'
-      action :create
-    end
+    mkdir '/etc/sts-agent'
+    command "chown -R sts-agent:sts-agent /etc/sts-agent"
+    command "chmod -R 0640 /etc/sts-agent"
 
     if debian?
       sys_type = 'debian'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -46,7 +46,6 @@ build do
   if linux?
     # Configuration files
     mkdir '/etc/sts-agent'
-    command "chown -R sts-agent:sts-agent /etc/sts-agent"
     command "chmod -R 0640 /etc/sts-agent"
 
     if debian?

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -45,7 +45,12 @@ build do
 
   if linux?
     # Configuration files
-    mkdir '/etc/sts-agent'
+    directory '/etc/sts-agent' do
+      owner 'sts-agent'
+      group 'sts-agent'
+      mode '0640'
+      action :create
+    end
 
     if debian?
       sys_type = 'debian'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -46,8 +46,6 @@ build do
   if linux?
     # Configuration files
     mkdir '/etc/sts-agent'
-    mkdir '/etc/sts-agent/branch_marker'
-    command "chmod -R 0640 /etc/sts-agent"
 
     if debian?
       sys_type = 'debian'
@@ -77,7 +75,6 @@ build do
     copy 'stackstate.conf.example', '/etc/sts-agent/stackstate.conf.example'
     copy 'connbeat.sh', '/opt/stackstate-agent/bin/connbeat.sh'
     copy 'connbeat.yml', '/etc/sts-agent/connbeat.yml'
-    copy 'connbeat.yml', '/etc/sts-agent/branch_marker.yml'
     mkdir "/etc/sts-agent/conf.d/auto_conf"
     copy 'conf.d', '/etc/sts-agent/'
 

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -77,6 +77,7 @@ build do
     copy 'stackstate.conf.example', '/etc/sts-agent/stackstate.conf.example'
     copy 'connbeat.sh', '/opt/stackstate-agent/bin/connbeat.sh'
     copy 'connbeat.yml', '/etc/sts-agent/connbeat.yml'
+    copy 'connbeat.yml', '/etc/sts-agent/branch_marker.yml'
     mkdir "/etc/sts-agent/conf.d/auto_conf"
     copy 'conf.d', '/etc/sts-agent/'
 

--- a/package-scripts/stackstate-agent/postinst
+++ b/package-scripts/stackstate-agent/postinst
@@ -76,7 +76,9 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
   # Set proper rights to the sts-agent user
   chown -R sts-agent:sts-agent ${CONFIG_DIR}
+  chmod -R 0640 ${CONFIG_DIR}
   chown -R sts-agent:sts-agent ${LOG_DIR}
+  chmod -R 0640 ${LOG_DIR}
   chown root:root /etc/init.d/stackstate-agent
   chown -R sts-agent:sts-agent ${INSTALL_DIR}
   chown root:root /opt/stackstate-agent/bin/connbeat


### PR DESCRIPTION
By default, all configuration files are readable by sts-agent user and group only.